### PR TITLE
Clarify the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,9 +79,16 @@ Now clone this repo and install the customization script.
 If you already have one, append this script to it.
 ```
 git clone https://github.com/ucb-bar/generator-bootcamp.git
+cd generator-bootcamp
 mkdir -p ~/.jupyter/custom
 cp source/custom.js ~/.jupyter/custom/custom.js
 ```
+
+And to start the bootcamp on your local machine:
+```
+jupyter notebook
+```
+
 
 ### Local Installation - Windows 
 


### PR DESCRIPTION
Instructions missing a `cd generator-bootcamp`. 

Also explain how to start the bootcamp if you're on a local machine.