### PR TITLE
Fix \* in 2.3 solution

### DIFF
--- a/2.3_control_flow.ipynb
+++ b/2.3_control_flow.ipynb
@@ -517,13 +517,13 @@
     "<label for=\"check-3\"><strong>Solution</strong></label>\n",
     "<article>\n",
     "<pre style=\"background-color:#f7f7f7\">\n",
-    "  square := io.x * io.x\n",
+    "  square := io.x \\* io.x\n",
     "  when(io.select === 0.U) {\n",
-    "    result := (square - (2.S * io.x)) + 1.S\n",
+    "    result := (square - (2.S \\* io.x)) + 1.S\n",
     "  }.elsewhen(io.select === 1.U) {\n",
-    "    result := (2.S * square) + (6.S * io.x) + 3.S\n",
+    "    result := (2.S \\* square) + (6.S \\* io.x) + 3.S\n",
     "  }.otherwise {\n",
-    "    result := (4.S * square) - (10.S * io.x) - 5.S\n",
+    "    result := (4.S \\* square) - (10.S \\* io.x) - 5.S\n",
     "  }\n",
     "</pre></article></div></section></div>"
    ]


### PR DESCRIPTION
Minor fix in one of the 2.3 solutions where the `*` was disappearing. This changes it to use `\*` like the other solutions.