### PR TITLE
Bugfix 3.6

### DIFF
--- a/3.6_types.ipynb
+++ b/3.6_types.ipynb
@@ -278,9 +278,9 @@
     "        case _ => throw new Exception(\"I give up!\")\n",
     "    }\n",
     "}\n",
-    "println(getVerilog(dut = () => new ConstantSum(3.U, 4.U)))\n",
-    "println(getVerilog(dut = () => new ConstantSum(-3.S, 4.S)))\n",
-    "println(getVerilog(dut = () => new ConstantSum(3.U, 4.S)))\n"
+    "println(getVerilog(dut = new ConstantSum(3.U, 4.U)))\n",
+    "println(getVerilog(dut = new ConstantSum(-3.S, 4.S)))\n",
+    "println(getVerilog(dut = new ConstantSum(3.U, 4.S)))\n"
    ]
   },
   {


### PR DESCRIPTION
getVerilog was expecting a UserModule, instead of a ()  => UserModule